### PR TITLE
fixed can view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /nbproject/private/
 /node_modules/
+.idea

--- a/src/Elements/TileElement.php
+++ b/src/Elements/TileElement.php
@@ -48,7 +48,7 @@ class TileElement extends BaseElement {
             if(!$tile->canView(Security::getCurrentUser())) {
                 continue;
             }
-            $sort = ($tile->Row * $this->Rows) + $tile->Col;
+            $sort = ($tile->Row * 1000) + $tile->Col;
             $tile->Sort = $sort;
             $retarray[$sort] = $tile;
         }

--- a/src/Models/Tile.php
+++ b/src/Models/Tile.php
@@ -401,7 +401,7 @@ class Tile extends DataObject {
      * @return string
      */
     public function getPreviewContent() {
-        return DBField::create_field(DBHTMLText::class, "(".$this->Col."x".$this->Row.")".$bob.$this->Content)->LimitCharacters(150);
+        return DBField::create_field(DBHTMLText::class, "(".$this->Col."x".$this->Row.")".$this->Content)->LimitCharacters(150);
     }
 
     /**

--- a/src/Models/Tile.php
+++ b/src/Models/Tile.php
@@ -401,7 +401,7 @@ class Tile extends DataObject {
      * @return string
      */
     public function getPreviewContent() {
-        return DBField::create_field(DBHTMLText::class, "(".$this->Col."x".$this->Row.")".$this->Content)->LimitCharacters(150);
+        return DBField::create_field(DBHTMLText::class, $this->Content)->LimitCharacters(150);
     }
 
     /**


### PR DESCRIPTION
Should fix issue with permissions, where a tile can be permissioned for SS group

This probably needs to be merged in conjunction with displaying changes other wise there will be holes
eg
![image](https://user-images.githubusercontent.com/15573766/57891880-23ef7f00-7891-11e9-9cc6-8d294638e086.png)
